### PR TITLE
Fixed issue with vlan tagging and addresses

### DIFF
--- a/src/js/mxgraph/js/miru/TopologyGenerator.js
+++ b/src/js/mxgraph/js/miru/TopologyGenerator.js
@@ -97,19 +97,19 @@ TopologyGenerator.prototype.processInterface = function (interfaceNode, nwSwitch
   host.setName(portName);
   // Sets defualt of 1gb speed for hosts if unconfigured
   var speed = interfaceNode.hasAttribute("speed") ? interfaceNode.getAttribute("speed") : 1000;
+  var tagged = interfaceNode.hasAttribute("tagged") ? interfaceNode.getAttribute("tagged") : false;
   for (var vlanNode of interfaceNode.children) {
-    this.processVlanNode(vlanNode, nwSwitch, port, host, speed);
+    this.processVlanNode(vlanNode, nwSwitch, port, host, speed, tagged);
   }
   return host;
 };
 
-TopologyGenerator.prototype.processVlanNode = function ( vlanNode, nwSwitch, port, host, speed) {
+TopologyGenerator.prototype.processVlanNode = function ( vlanNode, nwSwitch, port, host, speed, tagged) {
 
   var vid     = parseInt(vlanNode.getAttribute("vid"), 10);
   var ipv4    = vlanNode.getAttribute("ipv4_address") ? vlanNode.getAttribute("ipv4_address") : null;
   var ipv6    = vlanNode.getAttribute("ipv6_address") ? vlanNode.getAttribute("ipv6_address") : null;
   var mac     = vlanNode.getAttribute("ipv4_address") ? vlanNode.getAttribute("macaddresses") : null;
-  var tagged  = vlanNode.getAttribute("tagged") ? vlanNode.getAttribute("tagged") : false;
   vid = Number(vid);
   host.addInterface(nwSwitch.getName(), port, mac, ipv4, ipv6, vid, tagged);
 

--- a/src/js/mxgraph/js/miru/ixpapi.js
+++ b/src/js/mxgraph/js/miru/ixpapi.js
@@ -256,11 +256,14 @@ ixpapi.prototype.processLayer2Interfaces = async function (data, swname) {
                 ipv6 = vlan.ipaddresses.ipv6
 
                 port.name = iface["description"];
-                port.vlans[vlan.number] = {
-                    "macaddresses": mac,
-                    "ipv4_addresses": ipv4,
-                    "ipv6_addresses": ipv6
-                };
+                port.vlans[vlan.number] = {}
+                port.vlans[vlan.number].macaddresses = mac;
+                if (vlan.ipaddresses.ipv4 && vlan.ipaddresses.ipv4 != 'undefined'){
+                    port.vlans[vlan.number].ipv4_addresses = ipv4;
+                }
+                if (vlan.ipaddresses.ipv6 && vlan.ipaddresses.ipv6 != 'undefined'){
+                    port.vlans[vlan.number].ipv6_addresses = ipv6;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixed an issue where vlan tagging wasn't applied when generating configs

Fixed an issue where addresses would be "undefined" if they don't exist, instead of just being ignored as is expected